### PR TITLE
Added Base64 encoding for credentials to fix Basic Authentication

### DIFF
--- a/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
@@ -284,7 +284,7 @@ public class HttpWorkflowStepPlugin implements StepPlugin, Describable {
             authHeader = username + ":" + password;
             
             //As per RFC2617 the Basic Authentication standard has to send the credentials Base64 encoded. 
-            authHeader = "Basic" + com.dtolabs.rundeck.core.utils.Base64.encode(authHeader);
+            authHeader = "Basic " + com.dtolabs.rundeck.core.utils.Base64.encode(authHeader);
         } else if (authentication.equals(AUTH_OAUTH2)) {
             // Get an OAuth token and setup the auth header for OAuth
             String tokenEndpoint = options.containsKey("oauthTokenEndpoint") ? options.get("oauthTokenEndpoint").toString() : null;

--- a/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
+++ b/src/main/java/edu/ohio/ais/rundeck/HttpWorkflowStepPlugin.java
@@ -282,6 +282,9 @@ public class HttpWorkflowStepPlugin implements StepPlugin, Describable {
             }
 
             authHeader = username + ":" + password;
+            
+            //As per RFC2617 the Basic Authentication standard has to send the credentials Base64 encoded. 
+            authHeader = "Basic" + com.dtolabs.rundeck.core.utils.Base64.encode(authHeader);
         } else if (authentication.equals(AUTH_OAUTH2)) {
             // Get an OAuth token and setup the auth header for OAuth
             String tokenEndpoint = options.containsKey("oauthTokenEndpoint") ? options.get("oauthTokenEndpoint").toString() : null;


### PR DESCRIPTION
Basic Authentication was not working, so I made the required changes.

As per RFC2617/RFC7617 the Basic Authentication standard has to send the credentials Base64 encoded.
https://tools.ietf.org/html/rfc7617
https://tools.ietf.org/html/rfc2617
